### PR TITLE
fixed bug: 404 now has really a 404 error returned

### DIFF
--- a/src/App/RoutesLoader.php
+++ b/src/App/RoutesLoader.php
@@ -92,7 +92,7 @@ class RoutesLoader
         });
 
         $api->match('{url}', function(){
-            return new JsonResponse(['The requested end point does not exit', 404]);
+            return new JsonResponse(['error' => 'The requested end point does not exit'], 404);
         })->assert('url', '.+');
 
         $this->app->mount($this->app["api.endpoint"].'/'.$this->app["api.version"], $api);


### PR DESCRIPTION
Requesting a non-existing endpoint resulted in an HTML-200 code due to a typo. Fixed this to be a 404